### PR TITLE
Add support for native replications scheduled from JS.

### DIFF
--- a/ios/ReactCBLite.m
+++ b/ios/ReactCBLite.m
@@ -105,45 +105,26 @@ RCT_REMAP_METHOD(createPushReplication, createPushReplication:(NSString *)urlStr
 
 - (void) replicationChanged:(NSNotification *)notification {
     CBLReplication *replication = notification.object;
+    NSMutableDictionary *userInfo = [NSMutableDictionary new];
+    userInfo[@"pullReplication"] = @(replication.pull);
     switch (replication.status) {
-        case kCBLReplicationStopped: {
-            NSDictionary *userInfo = @{
-                                       @"status": @"kCBLReplicationStopped",
-                                       @"pullReplication": @(replication.pull)
-                                       };
-            [[NSNotificationCenter defaultCenter] postNotificationName:kReactCBLiteReplicationChangeNotification
-                                                                object:userInfo];
+        case kCBLReplicationStopped:
+            userInfo[@"status"] = @"kCBLReplicationStopped";
             break;
-        }
         case kCBLReplicationIdle:
-        {
-            NSDictionary *userInfo = @{
-                                       @"status": @"kCBLReplicationIdle",
-                                       @"pullReplication": @(replication.pull)
-                                       };
-            [[NSNotificationCenter defaultCenter] postNotificationName:kReactCBLiteReplicationChangeNotification
-                                                                object:userInfo];
+            userInfo[@"status"] = @"kCBLReplicationIdle";
             break;
-        }
-        case kCBLReplicationActive: {
-            NSDictionary *userInfo = @{@"status": @"kCBLReplicationActive",
-                                       @"pullReplication": @(replication.pull)
-                                       };
-            [[NSNotificationCenter defaultCenter] postNotificationName:kReactCBLiteReplicationChangeNotification
-                                                                object:userInfo];
+        case kCBLReplicationActive:
+            userInfo[@"status"] = @"kCBLReplicationActive";
             break;
-        }
-        case kCBLReplicationOffline: {
-            NSDictionary *userInfo = @{@"status": @"kCBLReplicationOffline",
-                                       @"pullReplication": @(replication.pull)
-                                       };
-            [[NSNotificationCenter defaultCenter] postNotificationName:kReactCBLiteReplicationChangeNotification
-                                                                object:userInfo];
+        case kCBLReplicationOffline:
+            userInfo[@"status"] = @"kCBLReplicationOffline";
             break;
-        }
         default:
             break;
     }
+    [[NSNotificationCenter defaultCenter] postNotificationName:kReactCBLiteReplicationChangeNotification
+                                                        object:userInfo];
 }
 
 - (CBLListener*) createListener: (int) port


### PR DESCRIPTION
When JavaScript calls createPullReplication:againstDatabase: a native CBLReplication will be created and subscribed to. When the replication changes, it will post a global notification that can be subscribed to from anywhere else in the app. This seemed a cleaner method rather than subscribing to a protocol where knowledge of the ReactCBLite module would be required by the delegate.