### PR TITLE
Update package.json to reference release tag 4.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-couchbase-lite",
-  "version": "0.6.0-basestone.1",
+  "version": "0.6.0-basestone.4",
   "description": "Install Couchbase Lite in your app to enable JSON sync.",
   "homepage": "http://developer.couchbase.com/mobile/",
   "keywords": [


### PR DESCRIPTION
As discussed on Slack, this updates the package.json to release tag 4. I'll update mobile-app if this looks okay.